### PR TITLE
 Add listener for collecting event from all entities managed by unit of work

### DIFF
--- a/src/EventListener/CollectsEventsFromAllEntitiesManagedByUnitOfWork.php
+++ b/src/EventListener/CollectsEventsFromAllEntitiesManagedByUnitOfWork.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace BornFree\TacticianDoctrineDomainEvent\EventListener;
+
+use BornFree\TacticianDomainEvent\Recorder\ContainsRecordedEvents;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Events;
+
+/**
+ * Class CollectsEventsFromAllEntitiesManagedByUnitOfWork
+ * @package BornFree\TacticianDoctrineDomainEvent\EventListener
+ */
+class CollectsEventsFromAllEntitiesManagedByUnitOfWork implements EventSubscriber, ContainsRecordedEvents
+{
+    /**
+     * @var array
+     */
+    private $collectedEvents = [];
+
+    /**
+     * @return array
+     */
+    public function getSubscribedEvents()
+    {
+        return [
+            Events::postFlush
+        ];
+    }
+
+    /**
+     * @param PostFlushEventArgs $event
+     */
+    public function postFlush(PostFlushEventArgs $event)
+    {
+        $uow = $event->getEntityManager()->getUnitOfWork();
+
+        foreach ($uow->getIdentityMap() as $entities) {
+            foreach ($entities as $entity){
+                $this->collectEventsFromEntity($entity);
+            }
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function releaseEvents()
+    {
+        $events = $this->collectedEvents;
+        $this->eraseEvents();
+
+        return $events;
+    }
+
+    /**
+     * Erases collected events from the entities
+     */
+    public function eraseEvents()
+    {
+        $this->collectedEvents = [];
+    }
+
+    /**
+     * @param mixed $entity
+     */
+    private function collectEventsFromEntity($entity)
+    {
+        if ($entity instanceof ContainsRecordedEvents) {
+            foreach ($entity->releaseEvents() as $event) {
+                $this->collectedEvents[] = $event;
+            }
+        }
+    }
+}

--- a/tests/EventListener/CollectsEventsFromAllEntitiesManagedByUnitOfWorkTest.php
+++ b/tests/EventListener/CollectsEventsFromAllEntitiesManagedByUnitOfWorkTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace BornFree\TacticianDoctrineDomainEvent\Tests\EventListener;
+
+use BornFree\TacticianDoctrineDomainEvent\EventListener\CollectsEventsFromAllEntitiesManagedByUnitOfWork;
+use BornFree\TacticianDomainEvent\Recorder\ContainsRecordedEvents;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\UnitOfWork;
+
+class CollectsEventsFromAllEntitiesManagedByUnitOfWorkTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CollectsEventsFromAllEntitiesManagedByUnitOfWork
+     */
+    private $listener;
+
+    public function setUp()
+    {
+        $this->listener = new CollectsEventsFromAllEntitiesManagedByUnitOfWork();
+    }
+
+    /**
+     * @test
+     */
+    public function it_subscribes_to_post_flush_event()
+    {
+        $events = $this->listener->getSubscribedEvents();
+
+        $this->assertEquals([Events::postFlush], $events);
+    }
+
+    /**
+     * @test
+     */
+    public function it_erases_events()
+    {
+        $event1 = new \stdClass();
+        $event2 = new \stdClass();
+
+        $expectedEvents = [$event1, $event2];
+        $postFlushEventArgs = $this->getPostFlushEventArgsMock($expectedEvents);
+
+        $this->listener->postFlush($postFlushEventArgs);
+
+        $collectedEvents = $this->listener->releaseEvents();
+
+        $this->assertCount(2, $collectedEvents);
+
+        $this->listener->eraseEvents();
+
+        $this->assertCount(0, $this->listener->releaseEvents());
+    }
+
+    /**
+     * @test
+     */
+    public function it_collects_events_on_lifecycle_event()
+    {
+        $event1 = new \stdClass();
+        $event2 = new \stdClass();
+
+        $expectedEvents = [$event1, $event2];
+
+        $postFlushEventArgs = $this->getPostFlushEventArgsMock($expectedEvents);
+
+        $this->listener->postFlush($postFlushEventArgs);
+
+        $collectedEvents = $this->listener->releaseEvents();
+
+        $this->assertEquals($expectedEvents, $collectedEvents);
+    }
+
+    /**
+     * @param $expectedEvents
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getPostFlushEventArgsMock($expectedEvents)
+    {
+        $entity = $this->getMockBuilder(ContainsRecordedEvents::class)
+            ->setMethods(['releaseEvents', 'eraseEvents'])
+            ->getMock();
+
+        $entity->expects($this->once())
+            ->method('releaseEvents')
+            ->will($this->returnValue($expectedEvents));
+
+        $entityManager = $this->getMockBuilder(EntityManager::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getUnitOfWork'])
+            ->getMock();
+
+        $uow = $this->getMockBuilder(UnitOfWork::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getIdentityMap'])
+            ->getMock();
+
+        $postFlushEventArgs = $this->getMockBuilder(PostFlushEventArgs::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getEntityManager'])
+            ->getMock();
+
+        $postFlushEventArgs->expects($this->once())
+            ->method('getEntityManager')
+            ->will($this->returnValue($entityManager));
+
+        $entityManager->expects($this->once())
+            ->method('getUnitOfWork')
+            ->will($this->returnValue($uow));
+
+        $uow->expects($this->once())
+            ->method('getIdentityMap')
+            ->will($this->returnValue([
+                'className' => [$entity]
+            ]));
+
+        return $postFlushEventArgs;
+    }
+}


### PR DESCRIPTION
Sometimes there might be an event recorded, but entity doesn't change so the event is not collected. It's also true when an aggregate root is recording events for its child entities. Here I would like to collect events from all entities which are managed by unit of work.

Similiar solution was proposed to SimpleBus: https://github.com/SimpleBus/DoctrineORMBridge/issues/3

If you would accept it then I'll create a PR to https://github.com/borNfreee/tactician-domain-events-bundle to provide configuration for choosing which listener should be used.